### PR TITLE
Fix image loading and messaging issues

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,6 +124,13 @@ button.active:hover {
     border: 1px solid #f5c6cb;
 }
 
+.message.info-text {
+    background-color: #d1ecf1;
+    color: #0c5460;
+    border: 1px solid #bee5eb;
+    font-style: normal;
+}
+
 .info-text {
     font-style: italic;
     color: #555;


### PR DESCRIPTION
## Summary
- allow `showMessage` to distinguish between info, success, and error states and apply dedicated styling for informational notices
- ensure non-TIFF uploads await decoding, surface read errors, and accept common extensions such as .jpg via MIME/extension fallback
- clear previous measurements before drawing a new line to preserve the user’s current measurement

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc484b1e74832f96c3bb3223a3c391